### PR TITLE
Allow user to specify a custom Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Or install it yourself as:
 
 The preferred type of notifications can be configured with:
 
-* `Prosopite.rails_logger = true`: Send warnings to the Rails log
-* `Prosopite.prosopite_logger = true`: Send warnings to `log/prosopite.log`
-* `Prosopite.stderr_logger = true`: Send warnings to STDERR
 * `Prosopite.raise = true`: Raise warnings as exceptions
+* `Prosopite.logger = Rails.logger`: Send warnings to a Logger instance (defaults to Rails.logger)
+
+If you want to customize how or where the warnings are logged you can pass an new instance of Logger.
+(see _Development Environment Usage_ for an example config)
 
 ## Development Environment Usage
 
@@ -129,13 +130,16 @@ class ApplicationController < ActionController::Base
   end
 end
 ```
-And the preferred notification channel should be configured:
+And the preferred notification channel can be customized:
 
 ```ruby
 # config/environments/development.rb
 
 config.after_initialize do
-  Prosopite.rails_logger = true
+  # logs to STDERR in red
+  Prosopite.logger = Logger.new(STDERR).tap do |l| 
+    l.formatter = -> (_, _, _, message) { "\e[91m#{message}\e[0m\n" }}
+  end
 end
 ```
 
@@ -147,7 +151,7 @@ Tests with N+1 queries can be configured to fail with:
 # config/environments/test.rb
 
 config.after_initialize do
-  Prosopite.rails_logger = true
+  Prosopite.logger = Rails.logger
   Prosopite.raise = true
 end
 ```

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -4,9 +4,7 @@ module Prosopite
   class NPlusOneQueriesError < StandardError; end
   class << self
     attr_writer :raise,
-                :stderr_logger,
-                :rails_logger,
-                :prosopite_logger,
+                :logger,
                 :whitelist
 
     def scan
@@ -119,9 +117,7 @@ module Prosopite
     end
 
     def send_notifications
-      @rails_logger ||= false
-      @stderr_logger ||= false
-      @prosopite_logger ||= false
+      @logger ||= Rails.logger
       @raise ||= false
 
       notifications_str = ''
@@ -136,15 +132,7 @@ module Prosopite
         notifications_str << "\n"
       end
 
-      Rails.logger.warn(notifications_str) if @rails_logger
-      $stderr.puts(notifications_str) if @stderr_logger
-
-      if @prosopite_logger
-        File.open(File.join(Rails.root, 'log', 'prosopite.log'), 'a') do |f|
-          f.puts(notifications_str)
-        end
-      end
-
+      @logger.warn(notifications_str)
       raise NPlusOneQueriesError.new(notifications_str) if @raise
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ require "active_record"
 
 require "prosopite"
 
+# silence logger
+Prosopite.logger = Logger.new(STDOUT).tap { |l| l.formatter = proc {} }
+
 class Minitest::Test
   include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Prosopite will default to Rails.logger but you can provide your custom
logger instance in case you want to change how or where errors
are logged.

(implements #8)