### PR TITLE
Allow Prosopite.scan with block

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Prosopite.scan
 Prosopite.finish
 ```
 
+or 
+
+```ruby
+Prosopite.scan do
+<code to scan>
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/charkost/prosopite.

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -21,6 +21,15 @@ module Prosopite
       @allow_list ||= []
 
       tc[:prosopite_scan] = true
+
+      if block_given?
+        begin
+          yield
+          finish
+        ensure
+          tc[:prosopite_scan] = false
+        end
+      end
     end
 
     def tc

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -78,6 +78,30 @@ class TestQueries < Minitest::Test
     Prosopite.finish
   end
 
+  def test_scan_with_block
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    assert_raises(Prosopite::NPlusOneQueriesError) do
+      Prosopite.scan do
+        Chair.last(20).each do |c|
+          c.legs.first
+        end
+      end
+    end
+  end
+
+  def test_scan_with_block_raising_error
+    begin
+      Prosopite.scan do
+        raise ArgumentError # raise sample error
+      end
+    rescue ArgumentError
+      assert_equal(false, Prosopite.scan?)
+    end
+  end
+
   def assert_n_plus_one
     assert_raises(Prosopite::NPlusOneQueriesError) do
       Prosopite.finish


### PR DESCRIPTION
Resolves https://github.com/charkost/prosopite/issues/11

Usage: 

```
Prosopite.scan do
  Chairs.all.each do |chair|
    chair.legs.count
  end
end
```