### PR TITLE
fix regexp warning

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -105,7 +105,7 @@ module Prosopite
 
       query.gsub!(/\btrue\b|\bfalse\b/i, "?")
 
-      query.gsub!(/[0-9+-][0-9a-f.xb+-]*/, "?")
+      query.gsub!(/[0-9+-][0-9a-f.x+-]*/, "?")
       query.gsub!(/[xb.+-]\?/, "?")
 
       query.strip!


### PR DESCRIPTION
When I ran the test, I got the following warning.

```
% rake test
/Users/pocari/repos/github.com/charkost/prosopite/lib/prosopite.rb:109: warning: character class has duplicated range: /[0-9+-][0-9a-f.xb+-]*/
-- create_table("legs", {:force=>true})
   -> 0.0034s
-- create_table("chairs", {:force=>true})
   -> 0.0003s
Run options: --seed 26878

# Running:

................................

Finished in 0.364233s, 87.8559 runs/s, 183.9482 assertions/s.

32 runs, 67 assertions, 0 failures, 0 errors, 0 skipsde
```

I have fixed it.
