### PR TITLE
Return error message from the check

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -1,3 +1,4 @@
+require 'bundler'
 
 module Prosopite
   class NPlusOneQueriesError < StandardError; end
@@ -164,6 +165,8 @@ module Prosopite
       end
 
       raise NPlusOneQueriesError.new(notifications_str) if @raise
+
+      notifications_str
     end
 
     def red(str)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
-require "minitest/autorun"
-require "factory_bot"
-require "active_record"
+require 'minitest/autorun'
+require 'factory_bot'
+require 'active_record'
 
-require "prosopite"
+require 'prosopite'
 
 class Minitest::Test
   include FactoryBot::Syntax::Methods

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -102,6 +102,19 @@ class TestQueries < Minitest::Test
     end
   end
 
+  def test_error_message
+    Prosopite.raise = false
+
+    message = Prosopite.scan do
+      Chair.last(20).each do |c|
+        c.legs.first
+      end
+    end
+
+    assert_match(/N\+1 queries detected:/, message)
+    Prosopite.raise = true
+  end
+
   def assert_n_plus_one
     assert_raises(Prosopite::NPlusOneQueriesError) do
       Prosopite.finish


### PR DESCRIPTION
There are multiple cases when you need to process the message manually e.g. custom test matcher or notificaiton. 
It'd be cool to have an opportunity to get the error message instead of an exception.