### PR TITLE
Skip ActiveRecord's SCHEMA queries

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -175,9 +175,9 @@ module Prosopite
       return if @subscribed
 
       ActiveSupport::Notifications.subscribe 'sql.active_record' do |_, _, _, _, data|
-        sql = data[:sql]
+        sql, name = data[:sql], data[:name]
 
-        if scan? && sql.include?('SELECT') && data[:cached].nil?
+        if scan? && name != "SCHEMA" && sql.include?('SELECT') && data[:cached].nil?
           location_key = Digest::SHA1.hexdigest(caller.join)
 
           tc[:prosopite_query_counter][location_key] += 1


### PR DESCRIPTION
This PR would close #26. This PR just adds a check to see that the query being made is not one of active record's `SCHEMA` queries.

Testing:

I have tested this locally in my rails app where this was breaking, and this fixed the problem. I tried to add some basic unit tests here too, but I don't think it is easily replicated with the current sqlite testing setup (so they pass either way) - but I can still push them up if it's helpful