### PR TITLE
Rename `allow_list` to `allow_stack_paths` + add ability to skip specific SQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Ignore notifications for call stacks containing one or more substrings:
 Prosopite.allow_stack_paths = ['substring_in_call_stack']
 ```
 
+Ignore notifications matching a specific SQL query:
+
+```ruby
+Prosopite.ignore_queries = [/regex_match/, "SELECT * from EXACT_STRING_MATCH"]
+```
+
 ## Scanning code outside controllers or tests
 
 All you have to do is to wrap the code with:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ WARNING: scan/finish should run before/after **each** test and NOT before/after 
 Ignore notifications for call stacks containing one or more substrings:
 
 ```ruby
-Prosopite.allow_list = ['substring_in_call_stack']
+Prosopite.allow_stack_paths = ['substring_in_call_stack']
 ```
 
 ## Scanning code outside controllers or tests

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -8,7 +8,13 @@ module Prosopite
                 :stderr_logger,
                 :rails_logger,
                 :prosopite_logger,
-                :allow_list
+                :allow_stack_paths
+
+    def allow_list=(value)
+      puts "Prosopite.allow_list= is deprecated. Use Prosopite.allow_stack_paths= instead."
+
+      self.allow_stack_paths = value
+    end
 
     def scan
       tc[:prosopite_scan] ||= false
@@ -20,7 +26,7 @@ module Prosopite
       tc[:prosopite_query_holder] = Hash.new { |h, k| h[k] = [] }
       tc[:prosopite_query_caller] = {}
 
-      @allow_list ||= []
+      @allow_stack_paths ||= []
 
       tc[:prosopite_scan] = true
 
@@ -75,8 +81,9 @@ module Prosopite
           next unless fingerprints.uniq.size == 1
 
           kaller = tc[:prosopite_query_caller][location_key]
+          allow_list = (@allow_stack_paths + DEFAULT_ALLOW_LIST)
+          is_allowed = kaller.any? { |f| allow_list.any? { |s| f.include?(s) } }
 
-          is_allowed = kaller.any? { |f| @allow_list.concat(DEFAULT_ALLOW_LIST).any? { |s| f.include?(s) } }
           unless is_allowed
             queries = tc[:prosopite_query_holder][location_key]
             tc[:prosopite_notifications][queries] = kaller


### PR DESCRIPTION
Hello, thank you for this great gem.

While trying to set it up, I glossed over what `Prosopite.allow_list` does, and assumed it accepted a list of SQL queries to ignore, rather than paths in the call stack. To make it a bit easier for future me / others, I'd like to suggest a more explicit name: `Prosopite.allow_stack_paths`.

Obviously it's your gem and I won't be sad if you reject this change but I figured it doesn't hurt to try. I also added some tests for the allowlist functionality as it is currently untested.

(I think a feature to skip specific query fragments would be handy too... happy to build that if you are interested.)