### PR TITLE
Add `Prosopite.pause` and `Prosopite.resume`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ Prosopite.scan do
 end
 ```
 
+## Pausing and resuming scans
+
+Scans can be paused:
+
+```ruby
+Prosopite.scan
+# <code to scan>
+Prosopite.pause
+# <code that has n+1s>
+Prosopite.resume
+# <code to scan>
+Prosopite.finish
+```
+
+An example of when you might use this is if you are [testing Active Jobs inline](https://guides.rubyonrails.org/testing.html#testing-jobs),
+and don't want to run Prosopite on background job code, just foreground app code. In that case you could write an [Active Job callback](https://edgeguides.rubyonrails.org/active_job_basics.html#callbacks) that pauses the scan while the job is running.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/charkost/prosopite.

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -38,6 +38,14 @@ module Prosopite
       Thread.current
     end
 
+    def pause
+      tc[:prosopite_scan] = false
+    end
+
+    def resume
+      tc[:prosopite_scan] = true
+    end
+
     def scan?
       tc[:prosopite_scan]
     end

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -102,6 +102,56 @@ class TestQueries < Minitest::Test
     end
   end
 
+  def test_pause_with_no_error_after_resume
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+
+    Prosopite.pause
+    Chair.last(20).each do |c|
+      c.legs.last
+    end
+
+    Prosopite.resume
+
+    assert_no_n_plus_ones
+  end
+
+  def test_pause_with_error_after_resume
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+
+    Prosopite.pause
+    Prosopite.resume
+
+    Chair.last(20).each do |c|
+      c.legs.last
+    end
+
+    assert_n_plus_one
+  end
+
+  def test_pause_and_do_not_resume
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+
+    Prosopite.pause
+
+    Chair.last(20).each do |c|
+      c.legs.last
+    end
+
+    assert_no_n_plus_ones
+  end
+
   def test_scan_with_block_raising_error
     begin
       Prosopite.scan do
@@ -116,5 +166,9 @@ class TestQueries < Minitest::Test
     assert_raises(Prosopite::NPlusOneQueriesError) do
       Prosopite.finish
     end
+  end
+
+  def assert_no_n_plus_ones
+    Prosopite.finish
   end
 end


### PR DESCRIPTION
I'm trying to migrate over from Bullet. We have a Delayed Job plugin at the moment, that disables Bullet while a background job is running and re-enables it when the job is complete. This way we can run Bullet in tests but have it only run on foreground code.

It looks this:

```ruby
module Delayed
  module Plugins
    class BulletDisable < Plugin
      callbacks do |lifecycle|
        lifecycle.around(:invoke_job) do |job, *args, &block|
          @bullet_was_enabled = Bullet.enabled?
          Bullet.enabled = false
          block.call(job, *args)
          Bullet.enabled = @bullet_was_enabled
        end
      end
    end
  end
end
```

This PR adds `Prosopite.pause` and `Prosopite.resume` which allows you to do the same thing with Prosopite. So our plugin would become this:

```ruby
module Delayed
  module Plugins
    class ProsopitePause < Plugin
      callbacks do |lifecycle|
        lifecycle.around(:invoke_job) do |job, *args, &block|
          Prosopite.pause
          block.call(job, *args)
          Prosopite.resume
        end
      end
    end
  end
end
```