### PR TITLE
Suggest using around_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ Prosopite auto-detection can be enabled on all controllers:
 ```ruby
 class ApplicationController < ActionController::Base
   unless Rails.env.production?
-    before_action do
+    around_action :n_plus_one_detection
+    
+    def n_plus_one_detection
       Prosopite.scan
-    end
-
-    after_action do
+      yield
+    ensure
       Prosopite.finish
     end
   end


### PR DESCRIPTION
Ensure that scan is finished after exceptions to avoid false positives after subsequent actions.