### PR TITLE
Make `Prosopite.resume` an alias of `Prosopite.scan`

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -50,7 +50,7 @@ module Prosopite
     end
 
     def resume
-      tc[:prosopite_scan] = true
+      scan
     end
 
     def scan?

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -257,6 +257,19 @@ class TestQueries < Minitest::Test
     assert_n_plus_one
   end
 
+  def test_resume_is_an_alias_of_scan
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.resume
+    Chair.last(20).each do |c|
+      c.legs.first
+    end
+
+    assert_n_plus_one
+  end
+
   private
   def assert_n_plus_one
     assert_raises(Prosopite::NPlusOneQueriesError) do


### PR DESCRIPTION
This simplifies the implementation a little. I came across this when I accidentally wrote this:

```ruby
Prosopite.resume
Prosopite.finish
```

and it crashed since I'd never called `scan`!

Turns out `scan` and `resume` basically do the same thing.