### PR TITLE
Allow regexs on allow_stack_paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Prosopite auto-detection can be enabled on all controllers:
 class ApplicationController < ActionController::Base
   unless Rails.env.production?
     around_action :n_plus_one_detection
-    
+
     def n_plus_one_detection
       Prosopite.scan
       yield
@@ -179,10 +179,10 @@ WARNING: scan/finish should run before/after **each** test and NOT before/after 
 
 ## Allow list
 
-Ignore notifications for call stacks containing one or more substrings:
+Ignore notifications for call stacks containing one or more substrings / regex:
 
 ```ruby
-Prosopite.allow_stack_paths = ['substring_in_call_stack']
+Prosopite.allow_stack_paths = ['substring_in_call_stack', /regex/]
 ```
 
 Ignore notifications matching a specific SQL query:
@@ -201,7 +201,7 @@ Prosopite.scan
 Prosopite.finish
 ```
 
-or 
+or
 
 ```ruby
 Prosopite.scan do

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -83,7 +83,7 @@ module Prosopite
 
           kaller = tc[:prosopite_query_caller][location_key]
           allow_list = (@allow_stack_paths + DEFAULT_ALLOW_LIST)
-          is_allowed = kaller.any? { |f| allow_list.any? { |s| f.include?(s) } }
+          is_allowed = kaller.any? { |f| allow_list.any? { |s| f.match?(s) } }
 
           unless is_allowed
             queries = tc[:prosopite_query_holder][location_key]

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -182,6 +182,22 @@ class TestQueries < Minitest::Test
     assert_no_n_plus_ones
   end
 
+  def test_allow_stack_paths_with_regex
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    # ...prosopite/test/test_queries.rb:195:in `block in test_allow_stack_paths_with_regex'
+    Prosopite.allow_stack_paths = [/test_queries.*test_allow_stack_paths_with_regex/]
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.first
+    end
+
+    assert_no_n_plus_ones
+  end
+
   def test_allow_stack_paths_does_not_match_query_source
     # 20 chairs, 4 legs each
     chairs = create_list(:chair, 20)


### PR DESCRIPTION
I would like to be able to ignore path by regex.

Example, If I have this:

```
app/services/users/massive_invitation_service.rb:25:in `run'
```

I want to avoid line number (it could be change easliy in the furure) and use only file + method name:

```ruby
'app/services/users/massive_invitation_service.rb:25:in `run '.match?(/massive_invitation_service\.rb.*run/)
```
