### PR TITLE
Change #scan to return the result of the block

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,19 @@ Prosopite.scan
 Prosopite.finish
 ```
 
-or
+In block form the `Prosopite.finish` is called automatically for you at the end of the block:
 
 ```ruby
 Prosopite.scan do
-<code to scan>
+  <code to scan>
+end
+```
+
+The result of the code block is also returned by `Prosopite.scan`, so you can wrap calls as follows:
+
+```ruby
+my_object = Prosopite.scan do
+  MyObjectFactory.create(params)
 end
 ```
 

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -34,8 +34,9 @@ module Prosopite
 
       if block_given?
         begin
-          yield
+          block_result = yield
           finish
+          block_result
         ensure
           tc[:prosopite_scan] = false
         end

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -167,6 +167,14 @@ class TestQueries < Minitest::Test
     end
   end
 
+  def test_scan_with_block_returns_result
+    actual_result = Prosopite.scan do
+      :result_of_block
+    end
+
+    assert_equal(:result_of_block, actual_result)
+  end
+
   def test_allow_stack_paths
     # 20 chairs, 4 legs each
     chairs = create_list(:chair, 20)


### PR DESCRIPTION
Previously Prosopite would return whatever the `finish` method returned. That meant if I wanted to check some code for N+1s I'd have to do this:

```
Prosopite.scan
something = my_code_here
Prosopite.finish
```

It's more useful to be able to do something like this, since it reduces the risk of forgetting a Prospite.finish

```
something = Prosopite.scan do
   my_code_here
end
```

