### PR TITLE
Allow overriding `Prosopite.raise` config to temporarily `raise` on N+1s

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -67,6 +67,24 @@ module Prosopite
       send_notifications if tc[:prosopite_notifications].present?
     end
 
+    def force_raise
+      tc[:prosopite_force_raise] = true
+    end
+
+    def unforce_raise
+      tc[:prosopite_force_raise] = false
+    end
+
+    def force_raise?
+      tc[:prosopite_force_raise] == true
+    end
+
+    def raise?
+      return true if force_raise?
+
+      @raise || false
+    end
+
     def create_notifications
       tc[:prosopite_notifications] = {}
 
@@ -160,7 +178,6 @@ module Prosopite
       @rails_logger ||= false
       @stderr_logger ||= false
       @prosopite_logger ||= false
-      @raise ||= false
 
       notifications_str = ''
 
@@ -185,7 +202,7 @@ module Prosopite
         end
       end
 
-      raise NPlusOneQueriesError.new(notifications_str) if @raise
+      raise NPlusOneQueriesError.new(notifications_str) if raise?
     end
 
     def red(str)

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -113,20 +113,20 @@ module Prosopite
       tc[:prosopite_query_caller] = nil
     end
 
-    def force_raise
-      tc[:prosopite_force_raise] = true
+    def start_raise
+      tc[:prosopite_local_raise] = true
     end
 
-    def unforce_raise
-      tc[:prosopite_force_raise] = false
+    def stop_raise
+      tc[:prosopite_local_raise] = false
     end
 
-    def force_raise?
-      tc[:prosopite_force_raise] == true
+    def local_raise?
+      tc[:prosopite_local_raise] == true
     end
 
     def raise?
-      force_raise? || !!@raise
+      local_raise? || !!@raise
     end
 
     def create_notifications

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -80,9 +80,7 @@ module Prosopite
     end
 
     def raise?
-      return true if force_raise?
-
-      @raise || false
+      force_raise? || !!@raise
     end
 
     def create_notifications

--- a/test/test_force_raise.rb
+++ b/test/test_force_raise.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class TestQueries < Minitest::Test
+  def teardown
+    Prosopite.raise = nil
+  end
+
+  def test_force_raise_raises_even_when_config_is_false
+    Prosopite.raise = false
+
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    refute Prosopite.raise?
+
+    force_raise do
+      Prosopite.scan
+
+      Chair.last(20).each do |c|
+        c.legs.last
+      end
+
+      assert_n_plus_one
+    end
+
+    refute Prosopite.raise?
+  end
+
+  private
+  def assert_n_plus_one
+    assert_raises(Prosopite::NPlusOneQueriesError) do
+      Prosopite.finish
+    end
+  end
+
+  def force_raise(&block)
+    Prosopite.force_raise
+    yield
+  ensure
+    Prosopite.unforce_raise
+  end
+end

--- a/test/test_force_raise.rb
+++ b/test/test_force_raise.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestQueries < Minitest::Test
+class TestForceRaise < Minitest::Test
   def teardown
     Prosopite.raise = nil
   end

--- a/test/test_local_raise.rb
+++ b/test/test_local_raise.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
 
-class TestForceRaise < Minitest::Test
+class TestLocalRaise < Minitest::Test
   def teardown
     Prosopite.raise = nil
   end
 
-  def test_force_raise_raises_even_when_config_is_false
+  def test_local_raise_raises_even_when_config_is_false
     Prosopite.raise = false
 
     chairs = create_list(:chair, 20)
@@ -13,7 +13,7 @@ class TestForceRaise < Minitest::Test
 
     refute Prosopite.raise?
 
-    force_raise do
+    local_raise do
       Prosopite.scan
 
       Chair.last(20).each do |c|
@@ -33,10 +33,10 @@ class TestForceRaise < Minitest::Test
     end
   end
 
-  def force_raise(&block)
-    Prosopite.force_raise
+  def local_raise(&block)
+    Prosopite.start_raise
     yield
   ensure
-    Prosopite.unforce_raise
+    Prosopite.stop_raise
   end
 end


### PR DESCRIPTION
Hello and thank you for this gem! 

I'm in the process of integrating Prosopite into our Rails codebase and we're going for an incremental approach by setting `Prosopite.raise = false` during configuration to avoid disrupting development. The problem for us with this is we also want to be able to raise on specific actions / controllers once N+1s have been eliminated from them with an around action. We considered setting config to always raise and only setting the around action for controllers / actions with N+1s resolved but we're also really keen on keeping the logs for existing N+1s

Here's an example of it's usage in a Rails app where `Prosopite.raise` is set to `false`:
```ruby
class ApplicationController < ActionController::Base
  ...

  def self.raise_on_n_plus_ones!(**options)
    return unless Rails.configuration.x.prosopite.enabled?

    prepend_around_action(:_raise_on_n_plus_ones, **options)
  end

  if Rails.configuration.x.prosopite.enabled?
    around_action :n_plus_one_detection

    def n_plus_one_detection
      Prosopite.scan
      yield
    ensure
      Prosopite.finish
    end

    def _raise_on_n_plus_ones
      Prosopite.force_raise
      yield
    ensure
      Prosopite.unforce_raise
    end
  end
end

class UserController < ApplicationController
  # only raises on N+1s introduced to the index action
  raise_on_n_plus_ones!(only: [:index])

  def index
    ...
  end

  def edit
    ...
  end
end
```

Please let me know if you'd prefer a different API or anything else and I'll fix it up, thanks!