### PR TITLE
Allow nested pause blocks without resuming inner blocks

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -48,14 +48,16 @@ module Prosopite
     end
 
     def pause
-      tc[:prosopite_scan] = false
-
       if block_given?
         begin
+          previous = tc[:prosopite_scan]
+          tc[:prosopite_scan] = false
           yield
         ensure
-          tc[:prosopite_scan] = true
+          tc[:prosopite_scan] = previous
         end
+      else
+        tc[:prosopite_scan] = false
       end
     end
 

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -180,6 +180,33 @@ class TestQueries < Minitest::Test
     assert_no_n_plus_ones
   end
 
+  def test_nested_pause_blocks
+    # 10 chairs, 4 legs each
+    chairs = create_list(:chair, 10)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+
+    inner_result = nil
+    outer_result = Prosopite.pause do
+      inner_result = Prosopite.pause do
+        :result
+      end
+
+      Chair.last(20).each do |c|
+        c.legs.last
+      end
+
+      :outer_result
+    end
+
+    assert_equal(:result, inner_result)
+
+    assert_equal(:outer_result, outer_result)
+
+    assert_no_n_plus_ones
+  end
+
   def test_pause_with_a_block_raising_error
     Prosopite.scan
 


### PR DESCRIPTION
Addresses part of #43.

Instead of always setting `tc[:prosopite_scan]` to true at the end of a `pause` block, we can remember the previous value from before the pause block and set it to that. This allows nesting of pauses, however deep, without resuming the scan until the outermost pause has reached the end of the block.