### PR TITLE
Make sure scan has properly started in scan? check

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -66,7 +66,8 @@ module Prosopite
     end
 
     def scan?
-      tc[:prosopite_scan]
+      !!(tc[:prosopite_scan] && tc[:prosopite_query_counter] &&
+         tc[:prosopite_query_holder] && tc[:prosopite_query_caller])
     end
 
     def finish


### PR DESCRIPTION
The previous check was not sufficient since it could by mocked by `Prosopite.resume` resulting to unexpected exceptions:
```
Prosopite.resume
Prosopite.scan
Prosopite.finish

NoMethodError: undefined method `each' for nil:NilClass from gems/prosopite-1.1.3/lib/prosopite.rb:84:in `create_notifications'
```
Credits to @iridakos for raising the issue.