### PR TITLE
Model class helper for ignoring prosopite on a specific query at runtime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     prosopite (1.3.0)
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ Pauses can be ignored with `Prosopite.ignore_pauses = true` in case you want to 
 An example of when you might use this is if you are [testing Active Jobs inline](https://guides.rubyonrails.org/testing.html#testing-jobs),
 and don't want to run Prosopite on background job code, just foreground app code. In that case you could write an [Active Job callback](https://edgeguides.rubyonrails.org/active_job_basics.html#callbacks) that pauses the scan while the job is running.
 
+## Explicitly allow N+1 even if prosopite is enabled
+
+Sometimes, you can have use cases where you intentionally want to allow N+1 queries, and thus don't want to Prosopite to trigger.
+
+There is a helper class method added to `ActiveRecord::Base` for this:
+
+```ruby
+Leg.last(10).each do |l|
+    l.prosopite_ignore.chair
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/charkost/prosopite.

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -233,7 +233,7 @@ module Prosopite
 
     def ignore_query?(sql)
       @ignore_queries ||= []
-      @ignore_queries.any? { |q| q === sql }
+      AnnotatedModel.ignored?(sql) || @ignore_queries.any? { |q| q === sql}
     end
 
     def subscribe

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -1,3 +1,6 @@
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.setup
 
 module Prosopite
   DEFAULT_ALLOW_LIST = %w(active_record/associations/preloader active_record/validations/uniqueness)

--- a/lib/prosopite/annotated_model.rb
+++ b/lib/prosopite/annotated_model.rb
@@ -1,0 +1,18 @@
+module Prosopite
+  module AnnotatedModel
+    extend ActiveSupport::Concern
+
+    ANNOTATION = '!prosopite:ignore!'
+    ANNOTATION_COMMENT = "/* #{ANNOTATION} */".freeze
+
+    class_methods do
+      def prosopite_ignore
+        annotate(ANNOTATION)
+      end
+    end
+
+    def self.ignored?(sql)
+      sql.include? ANNOTATION_COMMENT
+    end
+  end
+end

--- a/lib/prosopite/railtie.rb
+++ b/lib/prosopite/railtie.rb
@@ -1,0 +1,14 @@
+
+module Prosopite
+  class Railtie < Rails::Railtie
+    initializer "prosopite.insert_into_activerecord" do
+      ActiveSupport.on_load :active_record do
+        setup
+      end
+    end
+
+    def self.setup
+      ActiveRecord::Base.include Prosopite::AnnotatedModel
+    end
+  end
+end

--- a/prosopite.gemspec
+++ b/prosopite.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "zeitwerk"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "factory_bot"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ color = ENV['CI'] == 'true' || Minitest::Reporters::ANSI::Code.color?
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(color: color)]
 
 require "prosopite"
+Prosopite::Railtie.setup
 
 class Minitest::Test
   include FactoryBot::Syntax::Methods

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -322,6 +322,19 @@ class TestQueries < Minitest::Test
     assert_no_n_plus_ones
   end
 
+  def test_ignore_queries_with_annotation
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.prosopite_ignore.last
+    end
+
+    assert_no_n_plus_ones
+  end
+
   def test_ignore_queries_with_exact_match
     # 20 chairs, 4 legs each
     chairs = create_list(:chair, 20)


### PR DESCRIPTION
This is an extraction of some code we use with prosopite internally. There are a few places where we wanted to allow N+1, especially when it is outside of the normal web requests.

To do this, we add a class method to `ActiveRecord::Base` to add an annotation, and then we check it while checking against ignored queries.

Maybe not strictly necessary for this, but I also started a Railtie for prosopite for any rails configuration to be registered. That is where ActiveRecord::Base adds our module.

I also added zeitwerk for autoloading.

cc @geshwho who implemented this initially