### PR TITLE
Extend custom logger to allow taking the notifications directly and generate it's own string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Datadog, ELK stack, or similar, and don't want to have to remove the default red
 escaping data from messages sent to the Rails logger, or want to tag them
 differently with your own custom logger.
 
+The logger is expected to have a `warn` method that takes a string.
+
 ```ruby
 # Turns off logging with red highlights, but still sends them to the Rails logger
 Prosopite.custom_logger = Rails.logger
@@ -142,9 +144,30 @@ Prosopite.custom_logger = Rails.logger
 
 ```ruby
 # Use a completely custom logging instance
-Prosopite.custom_logger = MyLoggerClass.new
+class MyLogger
+  def warn(str)
+    # implementation
+  end
+end
 
+Prosopite.custom_logger = MyLogger.new
 ```
+
+Additionally, you can further customize how notifications are displayed by makni ga `warn` method that takes a `notifications` keyword:
+
+```ruby
+class FancifulLogger
+  def warn(notifications:)
+    notification.each do |queries, kaller|
+      # queries is an array of strings of santitized queries
+      # kaller is the callstack where it was called, and has been cleaned by Prosopite.backtrace_cleaner
+    end
+  end
+end
+
+Prosopite.custom_logger = FancifulLogger.new
+```
+
 
 ## Development Environment Usage
 

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -195,7 +195,7 @@ module Prosopite
     end
 
     def generate_notification_message(notifications)
-      notifications_str = StringIO.new
+      notifications_str = ''
       notifications.each do |queries, kaller|
         notifications_str << "N+1 queries detected:\n"
 
@@ -210,7 +210,7 @@ module Prosopite
         notifications_str << "\n"
       end
 
-      notifications_str.string
+      notifications_str
     end
 
     def send_notifications


### PR DESCRIPTION
We have a custom logger, but in order to inspect the callstack and customize the message, we end up throwing out the notification_str and reaching into `Thread.current[:prosopite_notifications]` directly to get it.

We also have to do our own filtering and cleaning because they haven't been cleaned yet.

I'm proposing this change to let the customer logger take the `notifications` keyword that gets the notifications OR a single argument that is the generated string. In support of that, I clean the callstacks before calling the custom logger.

cc @geshwho who wrote our custom logger. Hoping we can refactor it to be smaller with these changes 😁 