### PR TITLE
Make prosopite config accessible

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -12,11 +12,12 @@ module Prosopite
                 :rails_logger,
                 :prosopite_logger,
                 :custom_logger,
-                :allow_stack_paths,
-                :ignore_queries,
                 :ignore_pauses,
-                :min_n_queries,
                 :backtrace_cleaner
+
+    attr_accessor :allow_stack_paths,
+                  :ignore_queries,
+                  :min_n_queries
 
     def allow_list=(value)
       puts "Prosopite.allow_list= is deprecated. Use Prosopite.allow_stack_paths= instead."


### PR DESCRIPTION
This allows reading/writing to the config during runtime e.g. if you want to set a different query limit for a particular spec.

For example we want to set some central config for Prosopite, then override it for each test run, we can now read the existing config at the start of the spec and reset it at the end.