### PR TITLE
Support trilogy mysql adapter

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -131,7 +131,8 @@ module Prosopite
     end
 
     def fingerprint(query)
-      if ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
+      db_adapter = ActiveRecord::Base.connection.adapter_name.downcase
+      if db_adapter.include?('mysql') || db_adapter.include?('trilogy')
         mysql_fingerprint(query)
       else
         begin


### PR DESCRIPTION
Check if the adapter is mysql or trilogy to decide if the fingerprinting should be mysql or postgresql. `trilogy` is a new mysql adapter for ruby.

more info here https://github.com/trilogy-libraries

trilogy will also be a bundled adapter from rails 7.1