### PR TITLE
Fix: sidekiq middleware

### DIFF
--- a/lib/prosopite/middleware/sidekiq.rb
+++ b/lib/prosopite/middleware/sidekiq.rb
@@ -1,7 +1,7 @@
 module Prosopite
   module Middleware
     class Sidekiq
-      include Sidekiq::ServerMiddleware
+      include ::Sidekiq::ServerMiddleware
   
       def call(_worker, _msg, _queue)
         Prosopite.scan


### PR DESCRIPTION
correctly resolve sidekiq constant name,

to solve uninitialized constant Prosopite::Middleware::Sidekiq::ServerMiddleware (NameError)