### PR TITLE
Add query counts and maximum queries to log configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Or install it yourself as:
 
 The preferred type of notifications can be configured with:
 
-* `Prosopite.min_n_queries`: Minimum number of N queries to report per N+1 case. Defaults to 2.
+* `Prosopite.min_n_queries`: Minimum number of N queries required to report per N+1 case. Defaults to 2.
+* `Prosopite.display_max_n_queries`: Maximum number of queries to log per N+1 case. Defaults to all queries. Note that this does not change whether an N+1 is reported or not, only how many queries are logged.
+* `Prosopite.display_query_count = true`: Include the count of queries for each N+1 case logged.
 * `Prosopite.raise = true`: Raise warnings as exceptions
 * `Prosopite.rails_logger = true`: Send warnings to the Rails log
 * `Prosopite.prosopite_logger = true`: Send warnings to `log/prosopite.log`

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -18,7 +18,9 @@ module Prosopite
 
     attr_accessor :allow_stack_paths,
                   :ignore_queries,
-                  :min_n_queries
+                  :min_n_queries,
+                  :display_max_n_queries,
+                  :display_query_count
 
     def allow_list=(value)
       puts "Prosopite.allow_list= is deprecated. Use Prosopite.allow_stack_paths= instead."
@@ -217,9 +219,21 @@ module Prosopite
       notifications_str = ''
 
       tc[:prosopite_notifications].each do |queries, kaller|
-        notifications_str << "N+1 queries detected:\n"
+        notifications_str <<
+          if @display_query_count
+            "N+1 queries detected (#{queries.count}):\n"
+          else
+            "N+1 queries detected:\n"
+          end
 
-        queries.each { |q| notifications_str << "  #{q}\n" }
+        queries_to_display =
+          if @display_max_n_queries
+            queries.take(@display_max_n_queries)
+          else
+            queries
+          end
+
+        queries_to_display.each { |q| notifications_str << "  #{q}\n" }
 
         notifications_str << "Call stack:\n"
         kaller = backtrace_cleaner.clean(kaller)

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -432,6 +432,54 @@ class TestQueries < Minitest::Test
     Prosopite.min_n_queries = 2
   end
 
+  def test_display_max_n_queries
+    log_output = StringIO.new
+    Prosopite.custom_logger = Logger.new(log_output)
+    Prosopite.display_max_n_queries = 3
+
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.first
+    end
+
+    assert_n_plus_one
+
+    log_lines = log_output.string.split("\n").map(&:strip)
+    repeated_query =
+      %(SELECT "legs".* FROM "legs" WHERE "legs"."chair_id" = ? ORDER BY "legs"."id" ASC LIMIT ?)
+
+    assert_equal log_lines.count(repeated_query), 3
+  ensure
+    Prosopite.custom_logger = nil
+    Prosopite.display_max_n_queries = nil
+  end
+
+  def test_display_query_count
+    log_output = StringIO.new
+    Prosopite.custom_logger = Logger.new(log_output)
+    Prosopite.display_query_count = true
+
+    # 20 chairs, 4 legs each
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.first
+    end
+
+    assert_n_plus_one
+
+    assert_includes log_output.string, 'N+1 queries detected (20)'
+  ensure
+    Prosopite.custom_logger = nil
+    Prosopite.display_query_count = false
+  end
+
   private
   def assert_n_plus_one
     assert_raises(Prosopite::NPlusOneQueriesError) do


### PR DESCRIPTION
While using prosopite on an application with many N+1s, I wanted to focus my efforts on the N+1s with the most associated queries, so I added a count of queries.

I also found that I really only needed one query per N+1 to debug each issue, so I added a configuration to limit the number of queries logged.

The result looks something like this:

```
W, [2023-11-09T17:48:23.795072 #338497]  WARN -- : N+1 queries detected (20):
  SELECT "legs".* FROM "legs" WHERE "legs"."chair_id" = ? ORDER BY "legs"."id" ASC LIMIT ?
Call stack:
```

with this configuration:

```ruby
Prosopite.display_query_count = true
Prosopite.display_max_n_queries = 1
```

I decided to make them both optional in case anyone depends on the existing format.