### PR TITLE
Middleware::Rack: don't rely on `Prosopite.scan`'s block execution

### DIFF
--- a/lib/prosopite/middleware/rack.rb
+++ b/lib/prosopite/middleware/rack.rb
@@ -6,7 +6,10 @@ module Prosopite
       end
 
       def call(env)
-        Prosopite.scan { @app.call(env) }
+        Prosopite.scan 
+        @app.call(env)
+      ensure
+        Prosopite.finish
       end
     end
   end


### PR DESCRIPTION
* Change the rack middleware to no longer use the `Prosopite.scan`'s block execution syntax. This bring it inline with the sidekiq middleware.