### PR TITLE
docs/Update README.md with adding the minimum version required for Sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ end
 ```
 
 ### Sidekiq
-We also provide a middleware for sidekiq so that you can auto detect n+1 queries that may occur in a sidekiq job.
+We also provide a middleware for sidekiq `6.5.0+` so that you can auto detect n+1 queries that may occur in a sidekiq job.
 You just need to add the following to your sidekiq initializer.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ Sidekiq.configure_server do |config|
 end
 ```
 
+For applications running sidekiq < `6.5.0` but want to add the snippet, you can guard the snippet with something like this and remove it once you upgrade sidekiq:
+```ruby
+ if Sidekiq::VERSION >= '6.5.0' && (Rails.env.development? || Rails.env.test?)
+.....
+end
+```
+
 ## Allow list
 
 Ignore notifications for call stacks containing one or more substrings / regex:


### PR DESCRIPTION
Inspecting this [code change](https://github.com/sidekiq/sidekiq/commit/5698216e849bc9f14c6565d68d85cae5a058a6e4) this is the initial introduction of  `Sidekiq::ServerMiddleware` was in the version `6.5.0`,

so this PR is for adding that info in the readme file, because if the version is lower than `6.5.0` it will cause that error:
```
uninitialized constant Sidekiq::ServerMiddleware
/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/prosopite-1.4.1/lib/prosopite/middleware/sidekiq.rb:4:in `<class:Sidekiq>'
```