### PR TITLE
Allow cleaning backtraces used to identify N+1 queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The preferred type of notifications can be configured with:
 * `Prosopite.prosopite_logger = true`: Send warnings to `log/prosopite.log`. Defaults to `false`.
 * `Prosopite.stderr_logger = true`: Send warnings to STDERR. Defaults to `false`.
 * `Prosopite.backtrace_cleaner = my_custom_backtrace_cleaner`: use a different [ActiveSupport::BacktraceCleaner](https://api.rubyonrails.org/classes/ActiveSupport/BacktraceCleaner.html). Defaults to `Rails.backtrace_cleaner`.
+* `Prosopite.location_backtrace_cleaner`: clean backtrace used to identify N+1 queries. By default the full backtrace is used.
 * `Prosopite.custom_logger = my_custom_logger`: Set a custom logger. See the following section for the details. Defaults to `false`.
 * `Prosopite.enabled = true`: Enables or disables the gem. Defaults to `true`.
 

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -18,7 +18,8 @@ module Prosopite
 
     attr_accessor :allow_stack_paths,
                   :ignore_queries,
-                  :min_n_queries
+                  :min_n_queries,
+                  :location_backtrace_cleaner
 
     def allow_list=(value)
       puts "Prosopite.allow_list= is deprecated. Use Prosopite.allow_stack_paths= instead."
@@ -262,7 +263,8 @@ module Prosopite
 
         if scan? && name != "SCHEMA" && sql.include?('SELECT') && data[:cached].nil? && !ignore_query?(sql)
           query_caller = caller
-          location_key = Digest::SHA256.hexdigest(query_caller.join)
+          location = location_backtrace_cleaner ? location_backtrace_cleaner.clean(query_caller) : query_caller
+          location_key = Digest::SHA256.hexdigest(location.join)
 
           tc[:prosopite_query_counter][location_key] += 1
           tc[:prosopite_query_holder][location_key] << sql


### PR DESCRIPTION
Some gems cache missing methods after the first call. This can cause Prosopite to miss duplicate queries. For example, the N+1 query for `author` in the following `builder` template goes unnoticed if there are two posts since `xml.post` is a missing method that gets cached for the second call (see [1]).

```ruby

@posts.each do |post|
  xml.post do
    xml.author post.author.name
  end
end

```

Add `location_backtrace_cleaner` config option to modify backtraces that are used to identify queries. This allows to either silence problematic lines or even just use the backtrace inside the application itself:

```ruby
Prosopite.location_backtrace_cleaner = Rails.backtrace_silencer
```

[1] https://github.com/jimweirich/builder/blob/c80100f8205b2e918dbff605682b01ab0fabb866/lib/builder/xmlbase.rb#L91