### PR TITLE
Fix deprecation warning `ActiveRecord::Base.connection`

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -144,7 +144,7 @@ module Prosopite
     end
 
     def fingerprint(query)
-      db_adapter = ActiveRecord::Base.lease_connection.adapter_name.downcase
+      db_adapter = ActiveRecord::Base.with_connection.adapter_name.downcase
       if db_adapter.include?('mysql') || db_adapter.include?('trilogy')
         mysql_fingerprint(query)
       else

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -144,7 +144,7 @@ module Prosopite
     end
 
     def fingerprint(query)
-      db_adapter = ActiveRecord::Base.connection.adapter_name.downcase
+      db_adapter = ActiveRecord::Base.lease_connection.adapter_name.downcase
       if db_adapter.include?('mysql') || db_adapter.include?('trilogy')
         mysql_fingerprint(query)
       else


### PR DESCRIPTION
Addressing the deprecation warning from the stacktrace:

![image](https://github.com/user-attachments/assets/46b9fb87-2305-43e7-a9e9-78b48a2b45a3)
