### PR TITLE
Optimise `location_key` in `Prosopite.subscribe`

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -282,7 +282,7 @@ module Prosopite
 
         if scan? && name != "SCHEMA" && sql.include?('SELECT') && data[:cached].nil? && !ignore_query?(sql)
           query_caller = caller
-          location_key = Digest::SHA256.hexdigest(query_caller.join)
+          location_key = Digest::SHA256.hexdigest(query_caller.hash.to_s)
 
           tc[:prosopite_query_counter][location_key] += 1
           tc[:prosopite_query_holder][location_key] << sql


### PR DESCRIPTION
I've been profiling our (@buildkite's) tests where we've enabled Prosopite, and this `Array#join` shows up as a bit of a timing hotspot, depending on the size of the `caller`. It seems the goal here is to get a unique string key for each `caller`. We can use `Array#hash` for that which is much more performant.

<details>

<summary>Benchmarks</summary>

```ruby
# frozen_string_literal: true

require "benchmark/ips"
require "digest"

long_caller = 150.times.map { caller.sample.dup }

Benchmark.ips do |x|
  x.report("caller.join") do
    Digest::SHA256.hexdigest(long_caller.join)
  end

  x.report("caller.hash.to_s") do
    Digest::SHA256.hexdigest(long_caller.hash.to_s)
  end

  x.compare!
end

# ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
# Warming up --------------------------------------
#          caller.join    20.042k i/100ms
#     caller.hash.to_s    34.250k i/100ms
# Calculating -------------------------------------
#          caller.join    202.629k (± 2.1%) i/s    (4.94 μs/i) -      1.022M in   5.046676s
#     caller.hash.to_s    346.397k (± 1.4%) i/s    (2.89 μs/i) -      1.747M in   5.043580s

# Comparison:
#     caller.hash.to_s:   346397.3 i/s
#          caller.join:   202629.4 i/s - 1.71x  slower
```

</details>

I will also benefit from this as I've integrated prosopite into https://github.com/joshuay03/dial.