### PR TITLE
Avoid using `lease_connection`

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -160,12 +160,7 @@ module Prosopite
     end
 
     def fingerprint(query)
-      conn = if ActiveRecord::Base.respond_to?(:lease_connection)
-               ActiveRecord::Base.lease_connection
-             else
-               ActiveRecord::Base.connection
-             end
-      db_adapter = conn.adapter_name.downcase
+      db_adapter = ActiveRecord::Base.connection_db_config.adapter
       if db_adapter.include?('mysql') || db_adapter.include?('trilogy')
         mysql_fingerprint(query)
       else


### PR DESCRIPTION
Follow-up to https://github.com/charkost/prosopite/commit/d1eade0d68c05eff972fdb8a867adc397f924ddf

[Ideally, using `ActiveRecord::ConnectionHandling#lease_connection` usage should be avoided unless absolutely needed](https://github.com/rails/rails/pull/51349#issuecomment-3022324605):
> IMO calling .lease_connection in a place other than a script or rake task is a bug and should be reported to whatever gem does it.

We don't really need a connection here since we just need to figure out the adapter, which we can grab from `ActiveRecord::DatabaseConfigurations::HashConfig#adapter` which is already down-cased.