### PR TITLE
gemspec: require Ruby 2.7+ and Rails 7+ related gems

### DIFF
--- a/prosopite.gemspec
+++ b/prosopite.gemspec
@@ -25,11 +25,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", ">= 7.0"
+  spec.add_dependency "railties", ">= 7.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "factory_bot"
-  spec.add_development_dependency "railties"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "minitest-reporters"
 end

--- a/prosopite.gemspec
+++ b/prosopite.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "N+1 auto-detection for Rails with zero false positives / false negatives"
   spec.homepage      = "https://github.com/charkost/prosopite"
   spec.license       = "Apache-2.0"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/charkost/prosopite"
@@ -24,10 +24,11 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activerecord", ">= 7.0"
+
   spec.add_development_dependency "pry"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "factory_bot"
-  spec.add_development_dependency "activerecord"
   spec.add_development_dependency "railties"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "minitest-reporters"


### PR DESCRIPTION
- Prosopite uses `connection_db_config`, which is not available on older Active Record versions.
- Align runtime constraints with actual compatibility to avoid install-time/runtime mismatches (see #98).