### PR TITLE
Add caller_location_filter for custom location key computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ Ignore notifications matching a specific SQL query:
 Prosopite.ignore_queries = [/regex_match/, "SELECT * from EXACT_STRING_MATCH"]
 ```
 
+## Caller location filter
+
+Filter caller locations before computing the location key used to group queries. This is useful when certain gems produce different stack frames on the first (cold) vs subsequent (warm) calls to a method, causing Prosopite to split identical N+1 queries into separate groups.
+
+For example, `sorbet-runtime` uses different internal files (`call_validation.rb` vs `call_validation_2_7.rb`) on cold vs warm paths. With only 2 queries through a Sorbet-typed method, each gets a unique location key and Prosopite sees no N+1:
+
+```ruby
+Prosopite.caller_location_filter = ->(locations) {
+  locations.reject { |loc| loc.path.include?('sorbet-runtime') }
+}
+```
+
+The filter receives an array of `Thread::Backtrace::Location` objects and should return a filtered array. Only the filtered locations are used for computing the location key — the full unfiltered caller is still stored for notification display.
+
 ## Scanning code outside controllers or tests
 
 All you have to do is to wrap the code with:

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -18,7 +18,8 @@ module Prosopite
 
     attr_accessor :allow_stack_paths,
                   :ignore_queries,
-                  :min_n_queries
+                  :min_n_queries,
+                  :caller_location_filter
 
     def allow_list=(value)
       puts "Prosopite.allow_list= is deprecated. Use Prosopite.allow_stack_paths= instead."
@@ -277,9 +278,10 @@ module Prosopite
 
         if scan? && name != "SCHEMA" && sql.include?('SELECT') && data[:cached].nil? && !ignore_query?(sql)
           query_caller = caller_locations
+          filtered_caller = @caller_location_filter ? @caller_location_filter.call(query_caller) : query_caller
           # Calculate the location key with as few allocations as possible
           location_key = [].tap do |array|
-            query_caller.each do |loc|
+            filtered_caller.each do |loc|
               array << loc.path
               array << loc.lineno
             end

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -8,6 +8,7 @@ class TestQueries < Minitest::Test
   def teardown
     Prosopite.allow_stack_paths = []
     Prosopite.ignore_queries = nil
+    Prosopite.caller_location_filter = nil
     Prosopite.enabled = true
   end
 
@@ -422,6 +423,39 @@ class TestQueries < Minitest::Test
     Prosopite.scan
     Chair.last(20).each do |c|
       c.legs.last
+    end
+
+    assert_n_plus_one
+  end
+
+  def test_caller_location_filter
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    # Filter that strips test framework frames from location key computation.
+    # This simulates filtering gems with cold/warm path divergence (e.g.,
+    # sorbet-runtime) where the first call to a method produces different
+    # stack frames than subsequent calls, causing identical N+1 queries
+    # to be grouped under different location keys.
+    Prosopite.caller_location_filter = ->(locations) {
+      locations.reject { |loc| loc.path.include?('minitest') }
+    }
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.first
+    end
+
+    assert_n_plus_one
+  end
+
+  def test_caller_location_filter_nil_by_default
+    chairs = create_list(:chair, 20)
+    chairs.each { |c| create_list(:leg, 4, chair: c) }
+
+    Prosopite.scan
+    Chair.last(20).each do |c|
+      c.legs.first
     end
 
     assert_n_plus_one


### PR DESCRIPTION
## Problem

Some gems produce different stack frames on the first (cold) vs subsequent (warm) calls to a method. For example, **sorbet-runtime** uses `call_validation.rb` on the cold path and `call_validation_2_7.rb` on the warm path, plus an extra `_methods.rb` frame during cold method compilation. Other observability or instrumentation gems may add extra frames on the first call to an instrumented method.

Since Prosopite groups queries by hashing the full `caller_locations` into a `location_key`, these differing frames cause identical N+1 queries to be split into separate groups. With exactly 2 queries through such a method, each gets a unique location key (count=1 each) and Prosopite sees no N+1. With 3+ queries the warm path accumulates count>=2, making detection intermittent rather than reliable.

## Solution

Add a `caller_location_filter` configuration option — a callable that receives the raw `caller_locations` array and returns a filtered version. Only the filtered locations are used for computing the location key; the full unfiltered caller is still stored for notification display and `allow_stack_paths` matching.

```ruby
Prosopite.caller_location_filter = ->(locations) {
  locations.reject { |loc| loc.path.include?('sorbet-runtime') }
}
```

This is a minimal, non-breaking change:
- 1 new `attr_accessor` 
- 3 lines changed in `subscribe`
- Defaults to `nil` (no filtering), preserving existing behavior
- All existing tests pass unchanged

## Test plan

- Added `test_caller_location_filter` — verifies N+1 detection works with a filter applied
- Added `test_caller_location_filter_nil_by_default` — verifies default behavior is unchanged
- All 58 tests pass