### PR TITLE
Add optional context to Prosopite.scan and auto-populate it in Rack/Sidekiq middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Call stack:
   app/controllers/thank_you_controller.rb:3:in `each'
   app/controllers/thank_you_controller.rb:3:in `index':
   app/controllers/application_controller.rb:8:in `block in <class:ApplicationController>'
+Context:
+  GET /thank_you
 ```
 
 The need for prosopite emerged after dealing with various false positives / negatives using the
@@ -190,6 +192,7 @@ WARNING: scan/finish should run before/after **each** test and NOT before/after 
 
 Instead of using an `around_action` hook in a Rails Controller, you can also use the rack middleware instead
 implementing auto detect for all controllers.
+Notifications include the request method and path (e.g. `GET /thank_you`) as context.
 
 Add the following line into your `config/initializers/prosopite.rb` file.
 
@@ -202,6 +205,7 @@ end
 
 ### Sidekiq
 We also provide a middleware for sidekiq `6.5.0+` so that you can auto detect n+1 queries that may occur in a sidekiq job.
+Notifications include the worker class, job ID, and queue name (e.g. `MyWorker JID-abc123 queue=default`) as context.
 You just need to add the following to your sidekiq initializer.
 
 ```ruby

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -251,7 +251,12 @@ module Prosopite
           notifications_str << "  #{f}\n"
         end
 
-        notifications_str << "#{tc[:prosopite_context]}\n" if tc[:prosopite_context]
+        if tc[:prosopite_context]
+          notifications_str << "Context:\n"
+          tc[:prosopite_context].to_s.each_line do |line|
+            notifications_str << "  #{line.chomp}\n"
+          end
+        end
 
         notifications_str << "\n"
       end

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -236,8 +236,6 @@ module Prosopite
 
       notifications_str = String.new('')
 
-      notifications_str << "#{tc[:prosopite_context]}\n\n" if tc[:prosopite_context]
-
       tc[:prosopite_notifications].each do |queries, info|
         kaller = info[:kaller]
         duration_ms = info[:duration_ms]
@@ -252,6 +250,8 @@ module Prosopite
         kaller.each do |f|
           notifications_str << "  #{f}\n"
         end
+
+        notifications_str << "#{tc[:prosopite_context]}\n" if tc[:prosopite_context]
 
         notifications_str << "\n"
       end

--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -40,7 +40,7 @@ module Prosopite
       !enabled?
     end
 
-    def scan
+    def scan(context = nil)
       tc[:prosopite_scan] ||= false
       if scan? || disabled?
         return block_given? ? yield : nil
@@ -52,6 +52,7 @@ module Prosopite
       tc[:prosopite_query_holder] = Hash.new { |h, k| h[k] = [] }
       tc[:prosopite_query_caller] = {}
       tc[:prosopite_query_duration] = Hash.new(0.0)
+      tc[:prosopite_context] = context
 
       @allow_stack_paths ||= []
       @ignore_pauses ||= false
@@ -113,6 +114,7 @@ module Prosopite
       tc[:prosopite_query_holder] = nil
       tc[:prosopite_query_caller] = nil
       tc[:prosopite_query_duration] = nil
+      tc[:prosopite_context] = nil
     end
 
     def start_raise
@@ -233,6 +235,8 @@ module Prosopite
       @prosopite_logger ||= false
 
       notifications_str = String.new('')
+
+      notifications_str << "#{tc[:prosopite_context]}\n\n" if tc[:prosopite_context]
 
       tc[:prosopite_notifications].each do |queries, info|
         kaller = info[:kaller]

--- a/lib/prosopite/middleware/rack.rb
+++ b/lib/prosopite/middleware/rack.rb
@@ -6,7 +6,8 @@ module Prosopite
       end
 
       def call(env)
-        Prosopite.scan 
+        req = ::Rack::Request.new(env)
+        Prosopite.scan("#{req.request_method} #{req.path}")
         @app.call(env)
       ensure
         Prosopite.finish

--- a/lib/prosopite/middleware/sidekiq.rb
+++ b/lib/prosopite/middleware/sidekiq.rb
@@ -3,8 +3,8 @@ module Prosopite
     class Sidekiq
       include ::Sidekiq::ServerMiddleware
   
-      def call(_worker, _msg, _queue)
-        Prosopite.scan
+      def call(worker, msg, queue)
+        Prosopite.scan("#{worker.class.name} JID-#{msg['jid']} queue=#{queue}")
         yield
       ensure
         Prosopite.finish

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -466,7 +466,20 @@ class TestQueries < Minitest::Test
       end
     end
 
-    assert_match(/GET \/widgets\/1\n\n\z/, error.message)
+    assert_match(/Context:\n  GET \/widgets\/1\n\n\z/, error.message)
+  end
+
+  def test_multiline_context_in_notification
+    chairs = create_list(:chair, 5)
+    chairs.each { |c| create_list(:leg, 2, chair: c) }
+
+    error = assert_raises(Prosopite::NPlusOneQueriesError) do
+      Prosopite.scan("GET /widgets/1\nUser: 42") do
+        Chair.last(5).each { |c| c.legs.first }
+      end
+    end
+
+    assert_match(/Context:\n  GET \/widgets\/1\n  User: 42\n\n\z/, error.message)
   end
 
   private

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -456,6 +456,19 @@ class TestQueries < Minitest::Test
     assert_match(/N\+1 queries detected \(\d+\.\d+ms\)/, error.message)
   end
 
+  def test_context_in_notification
+    chairs = create_list(:chair, 5)
+    chairs.each { |c| create_list(:leg, 2, chair: c) }
+
+    error = assert_raises(Prosopite::NPlusOneQueriesError) do
+      Prosopite.scan("GET /widgets/1") do
+        Chair.last(5).each { |c| c.legs.first }
+      end
+    end
+
+    assert_match(/\AGET \/widgets\/1\n/, error.message)
+  end
+
   private
   def assert_n_plus_one
     assert_raises(Prosopite::NPlusOneQueriesError) do

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -466,7 +466,7 @@ class TestQueries < Minitest::Test
       end
     end
 
-    assert_match(/\AGET \/widgets\/1\n/, error.message)
+    assert_match(/GET \/widgets\/1\n\n\z/, error.message)
   end
 
   private


### PR DESCRIPTION
## Summary
- Add an optional `context` argument to `Prosopite.scan`, surfaced automatically by the Rack and Sidekiq middlewares (request method/path, or worker class/JID/queue).
- Each N+1 notification now ends with a `Context:` block, so a single WARN-level log line is self-contained.

## Why
The N+1 queries already show the concrete row values read in the loop (e.g. `customers.id = 501`), so context isn't needed to identify *that* data. What it adds is the entry-point parameter that never appears anywhere else in the report — e.g. which user's page was being rendered.

### Example

Request: `GET /users/42/orders` — the controller loads user `42`'s orders, then the view touches `order.customer` per order, causing N+1 on `Customer`.

Here is the report exactly as it appears in `log/prosopite.log` — no search, no cross-referencing another log, just reading this one entry:
```
N+1 queries detected (0.3ms):
  SELECT "customers".* FROM "customers" WHERE "customers"."id" = 501 LIMIT 1
  SELECT "customers".* FROM "customers" WHERE "customers"."id" = 502 LIMIT 1
  SELECT "customers".* FROM "customers" WHERE "customers"."id" = 503 LIMIT 1
Call stack:
  app/views/users/orders.html.erb:6:in `block in _app_views_users_orders_html_erb'
  app/views/users/orders.html.erb:5:in `each'
Context:
  GET /users/42/orders
```
Neither the queries (`customers.id` 501/502/503) nor the call stack mention `42`. Without the `Context:` line, there would be no way to tell which user's page produced this report from the report alone — you'd have to go correlate it with a separate access log by timestamp.

## Test plan
- [x] `bundle exec ruby -Itest test/test_queries.rb` (32 tests, 0 failures)