### PR TITLE
Treat TiDB adapter as MySQL for query fingerprinting

### DIFF
--- a/lib/prosopite.rb
+++ b/lib/prosopite.rb
@@ -164,7 +164,7 @@ module Prosopite
 
     def fingerprint(query)
       db_adapter = ActiveRecord::Base.connection_db_config.adapter
-      if db_adapter.include?('mysql') || db_adapter.include?('trilogy')
+      if db_adapter.include?('mysql') || db_adapter.include?('trilogy') || db_adapter.include?('tidb')
         mysql_fingerprint(query)
       else
         begin


### PR DESCRIPTION
## Summary
- TiDB is MySQL wire-protocol compatible, so `fingerprint` should route TiDB connections through `mysql_fingerprint` instead of falling through to the `pg_query`-based path.
- Adds a check for `'tidb'` in the adapter name alongside the existing `mysql`/`trilogy` checks.

## Test plan
- [ ] Verify N+1 detection works against a TiDB-backed Rails app